### PR TITLE
Add recap mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -383,6 +383,12 @@
           Enable Timer (experimental)
         </label>
 
+        <label class="checkbox" for="checkboxEnableRecapId">
+          <input type="checkbox" class="checkbox__input" name="checkboxEnableRecap" id="checkboxEnableRecapId" />
+          <div class="checkbox__box"></div>
+          Enable Recap mode
+        </label>
+
         <button type="button" class="btn-delete btn-overlay" onclick="clearUserData()">Delete saved data</button>
       </div>
 
@@ -636,6 +642,7 @@
 
       <button id="btn-show-hide-debug-info" onclick="showHideDebugInfo()">> Hide details</button>
       <div id="debug-info"></div>
+      <div id="recap-info"></div>
     </div>
 
     <!-- Scripts -->

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1283,6 +1283,7 @@ function updateCheckboxStatus() {
   ELEM_SELECT_STICKERING.selectedIndex = stickeringSelection;
   // ELEM_SELECT_CROSS_COLOR.selectedIndex = crossColorSelection;
   ELEM_CHECKBOX_TIMER_ENABLE.checked = timerEnabled;
+  ELEM_CHECKBOX_RECAP_ENABLE.checked = recapEnabled;
 }
 
 function enableDisableCheckboxConsiderAUF() {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -99,6 +99,7 @@ const ELEM_SELECT_STICKERING = document.getElementById("select-stickering");
 // const ELEM_SELECT_CROSS_COLOR = document.getElementById("select-cross-color");
 
 const ELEM_CHECKBOX_TIMER_ENABLE = document.getElementById("checkboxEnableTimerId");
+const ELEM_CHECKBOX_RECAP_ENABLE = document.getElementById("checkboxEnableRecapId");
 
 const ELEM_BUTTON_SETTINGS = document.querySelector(".btn-settings-train");
 const ELEM_CONTAINER_TRAIN_SETTINGS = document.getElementById("train-settings-container");
@@ -137,6 +138,9 @@ const ELEM_SELECT_GROUP = document.getElementById("select-group-id");
 let boolShowDebugInfo = true;
 const ELEM_BTN_SHOW_HIDE_DEBUG_INFO = document.getElementById("btn-show-hide-debug-info");
 const ELEM_DEBUG_INFO = document.getElementById("debug-info");
+
+const ELEM_RECAP_INFO = document.getElementById("recap-info");
+let recapDone = false;
 
 let flagdoublepress = false;
 
@@ -939,6 +943,7 @@ function keyup(e) {
  * - hintImageSelection
  * - hintAlgSelection
  * - timerEnabled
+ * - recapEnabled
  * - TrainCase.currentTrainCaseNumber
  * - trainCaseList
  *
@@ -966,11 +971,19 @@ function updateTrainCases() {
   stickeringSelection = ELEM_SELECT_STICKERING.selectedIndex;
   // crossColorSelection = ELEM_SELECT_CROSS_COLOR.selectedIndex;
   timerEnabled = ELEM_CHECKBOX_TIMER_ENABLE.checked;
+  recapEnabled = ELEM_CHECKBOX_RECAP_ENABLE.checked;
 
   if (timerEnabled) {
     ELEM_TIMER.style.display = "block";
   } else {
     ELEM_TIMER.style.display = "none";
+  }
+
+  if (recapEnabled) {
+    ELEM_RECAP_INFO.style.display = "block";
+    if (recapDone) recapDone = false;
+  } else {
+    ELEM_RECAP_INFO.style.display = "none";
   }
 
   closeOverlays();
@@ -1128,7 +1141,13 @@ function generateTrainCaseList() {
                 GROUP.scrambles
             );
 
-          trainCaseListTemp.push(new TrainCase(indexGroup, indexCase));
+          if (recapEnabled && leftSelection && rightSelection) {
+            // Push unmirrored and mirrored case (recap mode)
+            trainCaseListTemp.push(new TrainCase(indexGroup, indexCase, 0));
+            trainCaseListTemp.push(new TrainCase(indexGroup, indexCase, 1));
+          } else {
+            trainCaseListTemp.push(new TrainCase(indexGroup, indexCase));
+          }
         }
       }
     }
@@ -1164,6 +1183,9 @@ function nextScramble(nextPrevious) {
     TrainCase.currentTrainCaseNumber++;
     if (TrainCase.currentTrainCaseNumber >= trainCaseList.length) {
       generateTrainCaseList();
+      if (recapEnabled && !recapDone) {
+        recapDone = true;
+      }
       if (trainCaseList.length <= 0) return;
     }
   } else if (TrainCase.currentTrainCaseNumber > 0) {
@@ -1212,6 +1234,30 @@ function nextScramble(nextPrevious) {
   // This hides the hint image
   updateHintImgVisibility();
   saveUserData();
+
+  // Update recap info
+  if (recapEnabled) {
+    ELEM_RECAP_INFO.innerHTML = getRecapInfo();
+  }
+}
+
+/**
+ * 
+ */
+function getRecapInfo() {
+  let summary = "";
+  if (recapDone) {
+    summary = "Recap done (F5/refresh to restart)";
+  } else if (leftSelection && rightSelection) {
+    let remainingCases = trainCaseList.slice(TrainCase.currentTrainCaseNumber);
+    let remainingLeftCases = remainingCases.filter(item => item.getMirroring() == 1).length;
+    let remainingRightCases = remainingCases.filter(item => item.getMirroring() == 0).length;
+    summary = `${remainingLeftCases} left cases & ${remainingRightCases} right cases, left`;
+  } else {
+    let remainingCases = trainCaseList.length - TrainCase.currentTrainCaseNumber;
+    summary = `${remainingCases} cases left`;
+  }
+  return `<h3>Recap mode: ${summary}</h3>`;
 }
 
 /**

--- a/scripts/train_case.js
+++ b/scripts/train_case.js
@@ -11,10 +11,10 @@ class TrainCase {
   #algHintAUF;
   #AUFNum;
 
-  constructor(indexGroup, indexCase) {
+  constructor(indexGroup, indexCase, mirroring = undefined) {
     this.#indexGroup = indexGroup;
     this.#indexCase = indexCase;
-    this.#mirroring = undefined;
+    this.#mirroring = mirroring;
     this.#algHint = undefined;
     this.#indexScramble = undefined;
     this.#scramble = undefined;
@@ -31,6 +31,9 @@ class TrainCase {
 
   //#region Private Functions
   #setMirrored() {
+    // Check if already set (recap mode)
+    if (this.#mirroring !== undefined) return;
+    
     if (rightSelection && leftSelection) {
       this.#mirroring = parseInt(Math.floor(Math.random() * 2));
     } else if (rightSelection && !leftSelection) {

--- a/scripts/user_saved.js
+++ b/scripts/user_saved.js
@@ -68,6 +68,7 @@ let hintAlgSelection = 0;
 let stickeringSelection = 0
 // let crossColorSelection = 0;
 let timerEnabled = false;
+let recapEnabled = false;
 
 let firstVisit = true;
 let firstVisitTrain = true;
@@ -103,6 +104,7 @@ function saveUserData() {
   localStorage.setItem("stickeringSelection", stickeringSelection);
   // localStorage.setItem("crossColorSelection", crossColorSelection);
   localStorage.setItem("timerEnabled", timerEnabled);
+  localStorage.setItem("recapEnabled", recapEnabled);
 
   // Saving that the user just visited the site
   localStorage.setItem("firstVisit", false);

--- a/scripts/user_saved.js
+++ b/scripts/user_saved.js
@@ -65,7 +65,7 @@ let aufSelection = true;
 let considerAUFinAlg = true;
 let hintImageSelection = 2;
 let hintAlgSelection = 0;
-let stickeringSelection = 0
+let stickeringSelection = 0;
 // let crossColorSelection = 0;
 let timerEnabled = false;
 let recapEnabled = false;
@@ -185,6 +185,7 @@ function loadUserData() {
   aufSelection = loadBoolean("aufSelection", aufSelection);
   considerAUFinAlg = loadBoolean("considerAUFinAlg", considerAUFinAlg);
   timerEnabled = loadBoolean("timerEnabled", timerEnabled);
+  recapEnabled = loadBoolean("recapEnabled", recapEnabled);
 
   for (const GROUP of GROUPS) {
     // Load collapse state


### PR DESCRIPTION
Closes #94.

This adds a new "Enable Recap mode" setting
<img width="272" height="98" alt="billede" src="https://github.com/user-attachments/assets/482c0308-cc2e-40a9-88ca-d6cba550773b" />

When active adds information about current "Recap" session
Left and Right enabled:
<img width="432" height="256" alt="billede" src="https://github.com/user-attachments/assets/1f826fc6-6e13-4952-8813-2bc57e1d57bd" />
Left OR Right enabled:
<img width="324" height="62" alt="billede" src="https://github.com/user-attachments/assets/a3cb5c70-8656-43a2-9ca3-37c707323546" />

When all cases has been done:
<img width="458" height="42" alt="billede" src="https://github.com/user-attachments/assets/568ef6cc-1e74-4eee-a8aa-5d9286a5c80d" />

Note to solve the issue mentioned in #94 (about left and right being active results in only "half" the number of expected cases) this PR pushes the unmirrored aswell as the mirrored case to trainCaseList (when left and right is active and also recap is enabled).