### PR TITLE
Better random shuffle for cases

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1237,10 +1237,21 @@ function generateTrainCaseList() {
   if (trainCaseListTemp.length == 0) ELEM_SCRAMBLE.innerHTML = "no case selected";
 
   // Randomize Cases
-  trainCaseListTemp.sort(() => Math.random() - 0.5);
+  shuffleArray(trainCaseListTemp);
 
   // Add new cases to current list
   trainCaseList = trainCaseList.concat(trainCaseListTemp);
+}
+
+/**
+ * https://stackoverflow.com/a/12646864
+ * Less biased shuffle
+ */
+function shuffleArray(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
 }
 
 /**


### PR DESCRIPTION
Sorry for not creating a issue first.

But when using the new recap mode it has become very apparent that the current method for randomizing the cases:
https://github.com/Dave2ooo/F2LTrainer/blob/df9027e9ab17f83a9952c989b01a4e0ee0d958aa/scripts/main.js#L1240
Especially when only recapping a few cases.

It's biased and some times not very random, see for example this [article](https://itnext.io/stop-shuffling-with-sort-math-random-0-5-d5e6293c1f0c)

This PR changes the shuffling of the array to use Durstenfeld shuffling.


