### PR TITLE
Refactor group data into class-backed registry

### DIFF
--- a/scripts/groups.js
+++ b/scripts/groups.js
@@ -122,6 +122,15 @@ class Group {
     return this.customAlgorithmsRight[indexCase];
   }
 
+  setCustomAlgorithm(side, indexCase, value) {
+    if (side === "left") {
+      this.customAlgorithmsLeft[indexCase] = value;
+      return this.customAlgorithmsLeft[indexCase];
+    }
+    this.customAlgorithmsRight[indexCase] = value;
+    return this.customAlgorithmsRight[indexCase];
+  }
+
   getAlgorithmForSide(indexCase, side) {
     const selection = this.getAlgorithmSelection(side, indexCase);
     const algorithms = this.getAlgorithmPool(indexCase);

--- a/scripts/groups.js
+++ b/scripts/groups.js
@@ -1,6 +1,159 @@
 // Source https://github.com/Dave2ooo/F2LTrainer
 
-const BASIC_COLLECTION = {
+class Group {
+  constructor(config) {
+    this.saveName = config.saveName;
+    this.saveNameCasesURL = config.saveNameCasesURL;
+    this.saveNameAlgURL = config.saveNameAlgURL;
+    this.name = config.name;
+    this.idName = config.idName;
+    this.scrambles = config.scrambles;
+    this.algorithms = config.algorithms;
+    this.algorithmSelectionRight = config.algorithmSelectionRight;
+    this.algorithmSelectionLeft = config.algorithmSelectionLeft;
+    this.identicalAlgorithm = config.identicalAlgorithm;
+    this.caseSelection = config.caseSelection;
+    this.customAlgorithmsRight = config.customAlgorithmsRight;
+    this.customAlgorithmsLeft = config.customAlgorithmsLeft;
+    this.trash = config.trash;
+    this.collapse = config.collapse;
+    this.solveCounter = config.solveCounter;
+    this.imgPath = config.imgPath;
+    this.numberCases = config.numberCases;
+    this.categoryNames = config.categoryNames;
+    this.categoryCases = config.categoryCases;
+    this.caseNumberMapping = config.caseNumberMapping;
+    this.piecesToHide = config.piecesToHide;
+    this.ignoreAUF = config.ignoreAUF ?? [];
+    this.resetDomState();
+  }
+
+  resetDomState() {
+    this.categoryContainer = [];
+    this.collapseContainer = [];
+    this.categoryCollapseImg = [];
+    this.headingCategoryName = [];
+    this.btnChangeLearningState = [[], [], []];
+    this.divContainer = [];
+    this.caseNumber = [];
+    this.imgContainer = [];
+    this.imgCase = [];
+    this.imgCaseLeft = [];
+    this.algorithm = [];
+    this.divAlgorithm = [];
+    this.btnContainer = [];
+    this.btnMirror = [];
+    this.imgMirror = [];
+    this.flagMirrored = [];
+    this.btnEdit = [];
+    this.imgEdit = [];
+    this.btnDelete = [];
+    this.imgTrash = [];
+    this.trashElementContainer = [];
+    this.caseNumberTrash = [];
+    this.imgContainerTrash = [];
+    this.imgCaseTrash = [];
+    this.btnRecover = [];
+  }
+
+  getId() {
+    return this.idName;
+  }
+
+  getCaseState(indexCase) {
+    return this.caseSelection[indexCase];
+  }
+
+  setCaseState(indexCase, state) {
+    this.caseSelection[indexCase] = state;
+    return this.caseSelection[indexCase];
+  }
+
+  cycleCaseState(indexCase) {
+    const nextState = (this.getCaseState(indexCase) + 1) % 3;
+    return this.setCaseState(indexCase, nextState);
+  }
+
+  toggleCategory(indexCategory) {
+    this.collapse[indexCategory] = !this.collapse[indexCategory];
+    return this.collapse[indexCategory];
+  }
+
+  isCategoryCollapsed(indexCategory) {
+    return this.collapse[indexCategory];
+  }
+
+  getScramblesForCase(indexCase) {
+    return this.scrambles[indexCase + 1] ?? [];
+  }
+
+  getRandomScrambleForCase(indexCase) {
+    const scrambles = this.getScramblesForCase(indexCase);
+    if (!scrambles.length) {
+      return { index: 0, scramble: "" };
+    }
+    const index = Math.floor(Math.random() * scrambles.length);
+    return { index, scramble: scrambles[index] };
+  }
+
+  getAlgorithmPool(indexCase) {
+    return this.algorithms[indexCase + 1] ?? [];
+  }
+
+  getAlgorithmSelection(side, indexCase) {
+    if (side === "left") {
+      return this.algorithmSelectionLeft[indexCase];
+    }
+    return this.algorithmSelectionRight[indexCase];
+  }
+
+  setAlgorithmSelection(side, indexCase, value) {
+    if (side === "left") {
+      this.algorithmSelectionLeft[indexCase] = value;
+    } else {
+      this.algorithmSelectionRight[indexCase] = value;
+    }
+  }
+
+  getCustomAlgorithm(side, indexCase) {
+    if (side === "left") {
+      return this.customAlgorithmsLeft[indexCase];
+    }
+    return this.customAlgorithmsRight[indexCase];
+  }
+
+  getAlgorithmForSide(indexCase, side) {
+    const selection = this.getAlgorithmSelection(side, indexCase);
+    const algorithms = this.getAlgorithmPool(indexCase);
+    if (selection >= algorithms.length) {
+      return this.getCustomAlgorithm(side, indexCase);
+    }
+    const baseAlg = algorithms[selection];
+    if (side === "left") {
+      if (typeof StringManipulation !== "undefined" && typeof StringManipulation.mirrorAlg === "function") {
+        return StringManipulation.mirrorAlg(baseAlg);
+      }
+      return baseAlg;
+    }
+    return baseAlg;
+  }
+
+  shouldIgnoreAUF(caseNumber) {
+    return this.ignoreAUF.includes(caseNumber);
+  }
+
+  getPiecesToHide(indexCase) {
+    if (!Array.isArray(this.piecesToHide)) return undefined;
+    return this.piecesToHide[indexCase];
+  }
+
+  getCaseLabel(indexCase) {
+    if (!this.caseNumberMapping) return undefined;
+    return this.caseNumberMapping[indexCase + 1];
+  }
+}
+
+const BASIC_COLLECTION = new Group({
   // renamed!!!!! from basicCollection
   saveName: "basic_",
   saveNameCasesURL: "bc",
@@ -49,35 +202,10 @@ const BASIC_COLLECTION = {
     [27, 30, 25],
     [29, 28, 26],
   ],
-  categoryContainer: [],
-  collapseContainer: [],
-  categoryCollapseImg: [],
-  headingCategoryName: [],
-  btnChangeLearningState: [[], [], []],
-  divContainer: [],
-  caseNumber: [],
-  imgContainer: [],
-  imgCase: [],
-  imgCaseLeft: [],
-  algorithm: [],
-  divAlgorithm: [],
-  btnContainer: [],
-  btnMirror: [],
-  imgMirror: [],
-  flagMirrored: [],
-  btnEdit: [],
-  imgEdit: [],
-  btnDelete: [],
-  imgTrash: [],
-  trashElementContainer: [],
-  caseNumberTrash: [],
-  imgContainerTrash: [],
-  imgCaseTrash: [],
-  btnRecover: [],
   ignoreAUF: [37, 38, 39, 40, 41],
-};
+});
 
-const BASIC_BACK_COLLECTION = {
+const BASIC_BACK_COLLECTION = new Group({
   // renamed!!!!! from basicBackCollection
   saveName: "basicBack_",
   saveNameCasesURL: "bbc",
@@ -126,35 +254,10 @@ const BASIC_BACK_COLLECTION = {
     [28, 29, 26],
     [30, 27, 25],
   ],
-  categoryContainer: [],
-  collapseContainer: [],
-  categoryCollapseImg: [],
-  headingCategoryName: [],
-  btnChangeLearningState: [[], [], []],
-  divContainer: [],
-  caseNumber: [],
-  imgContainer: [],
-  imgCase: [],
-  imgCaseLeft: [],
-  algorithm: [],
-  divAlgorithm: [],
-  btnContainer: [],
-  btnMirror: [],
-  imgMirror: [],
-  flagMirrored: [],
-  btnEdit: [],
-  imgEdit: [],
-  btnDelete: [],
-  imgTrash: [],
-  trashElementContainer: [],
-  caseNumberTrash: [],
-  imgContainerTrash: [],
-  imgCaseTrash: [],
-  btnRecover: [],
   ignoreAUF: [37, 38, 39, 40, 41],
-};
+});
 
-const ADVANCED_COLLECTION = {
+const ADVANCED_COLLECTION = new Group({
   // renamed!!!!! from advancedCollection
   saveName: "advanced_",
   saveNameCasesURL: "ac",
@@ -221,32 +324,6 @@ const ADVANCED_COLLECTION = {
     59: "39B",
     60: "39F",
   },
-
-  categoryContainer: [],
-  collapseContainer: [],
-  categoryCollapseImg: [],
-  headingCategoryName: [],
-  btnChangeLearningState: [[], [], []],
-  divContainer: [],
-  caseNumber: [],
-  imgContainer: [],
-  imgCase: [],
-  imgCaseLeft: [],
-  algorithm: [],
-  divAlgorithm: [],
-  btnContainer: [],
-  btnMirror: [],
-  imgMirror: [],
-  flagMirrored: [],
-  btnEdit: [],
-  imgEdit: [],
-  btnDelete: [],
-  imgTrash: [],
-  trashElementContainer: [],
-  caseNumberTrash: [],
-  imgContainerTrash: [],
-  imgCaseTrash: [],
-  btnRecover: [],
   piecesToHide: [
     "br",
     "br",
@@ -311,9 +388,9 @@ const ADVANCED_COLLECTION = {
   ],
   // fr: front-right, fl: front-left, br: back-right, bl: back-left
   ignoreAUF: [],
-};
+});
 
-const EXPERT_COLLECTION = {
+const EXPERT_COLLECTION = new Group({
   // renamed!!!!! from expertCollection
   saveName: "expert_",
   saveNameCasesURL: "ec",
@@ -348,35 +425,42 @@ const EXPERT_COLLECTION = {
     [10, 11, 12, 13, 14, 15],
     [16, 17],
   ],
-
-  categoryContainer: [],
-  collapseContainer: [],
-  categoryCollapseImg: [],
-  headingCategoryName: [],
-  btnChangeLearningState: [[], [], []],
-  divContainer: [],
-  caseNumber: [],
-  imgContainer: [],
-  imgCase: [],
-  imgCaseLeft: [],
-  algorithm: [],
-  divAlgorithm: [],
-  btnContainer: [],
-  btnMirror: [],
-  imgMirror: [],
-  flagMirrored: [],
-  btnEdit: [],
-  imgEdit: [],
-  btnDelete: [],
-  imgTrash: [],
-  trashElementContainer: [],
-  caseNumberTrash: [],
-  imgContainerTrash: [],
-  imgCaseTrash: [],
-  btnRecover: [],
   piecesToHide: ["br", "br", "fl", "fl", "fl", "fl", "fl", "br", "fr", "fl", "br", "fl", "br", "fl", "br", "fl", "br"],
   // fr: front-right, fl: front-left, br: back-right, bl: back-left
   ignoreAUF: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
-};
+});
 
-const GROUPS = [BASIC_COLLECTION, BASIC_BACK_COLLECTION, ADVANCED_COLLECTION, EXPERT_COLLECTION];
+const GROUPS = new Map([
+  [BASIC_COLLECTION.idName, BASIC_COLLECTION],
+  [BASIC_BACK_COLLECTION.idName, BASIC_BACK_COLLECTION],
+  [ADVANCED_COLLECTION.idName, ADVANCED_COLLECTION],
+  [EXPERT_COLLECTION.idName, EXPERT_COLLECTION],
+]);
+
+const GROUP_ID_LIST = Array.from(GROUPS.keys());
+
+function getGroupIds() {
+  return GROUP_ID_LIST.slice();
+}
+
+function getGroupCount() {
+  return GROUP_ID_LIST.length;
+}
+
+function getGroupIdByIndex(index) {
+  return GROUP_ID_LIST[index];
+}
+
+function getGroupByIndex(index) {
+  return GROUPS.get(getGroupIdByIndex(index));
+}
+
+function getGroupIndexById(id) {
+  return GROUP_ID_LIST.indexOf(id);
+}
+
+function forEachGroup(callback) {
+  GROUP_ID_LIST.forEach((id, index) => {
+    callback(GROUPS.get(id), index, id);
+  });
+}

--- a/scripts/left_case_loader.js
+++ b/scripts/left_case_loader.js
@@ -1,11 +1,11 @@
 window.addEventListener("load", () => {
-    if (typeof GROUPS !== "undefined" && GROUPS.length) {
+    if (typeof GROUPS !== "undefined" && getGroupCount()) {
         addLeftImages();
     }
 });
 
 function addLeftImages() {
-    GROUPS.forEach((GROUP, groupIndex) => {
+    forEachGroup((GROUP) => {
         if (!GROUP.imgCase || !GROUP.imgCase.length) return;
 
         if (!GROUP.imgCaseLeft) GROUP.imgCaseLeft = [];

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -610,8 +610,8 @@ function updateAlg() {
   }
 
   // "Save" custom algs from global variable
-  GROUP.customAlgorithmsRight[INDEX_CASE] = editAlgGlobal.customAlgRight;
-  GROUP.customAlgorithmsLeft[INDEX_CASE] = editAlgGlobal.customAlgLeft;
+  GROUP.setCustomAlgorithm("right", INDEX_CASE, editAlgGlobal.customAlgRight);
+  GROUP.setCustomAlgorithm("left", INDEX_CASE, editAlgGlobal.customAlgLeft);
 
   // "Save" alg selection from global variable
   GROUP.setAlgorithmSelection("right", INDEX_CASE, editAlgGlobal.selectedAlgNumberRight);
@@ -775,6 +775,7 @@ function customAlgSelected() {
   const INDEX_GROUP = editAlgGlobal.indexGroup;
   const INDEX_CASE = editAlgGlobal.indexCase;
   const GROUP = getGroupByIndex(INDEX_GROUP);
+  const algorithmPool = GROUP.getAlgorithmPool(INDEX_CASE);
 
   // Set background to transparent on all algs
   ELEM_EDITALG_LISTENTRY.forEach((element) => {

--- a/scripts/user_saved.js
+++ b/scripts/user_saved.js
@@ -111,7 +111,7 @@ function saveUserData() {
   // Saving that the user just visited the site
   localStorage.setItem("firstVisit", false);
 
-  for (const GROUP of GROUPS) {
+  for (const GROUP of GROUPS.values()) {
     // Save Collapse
     localStorage.setItem(GROUP.saveName + "collapse", JSON.stringify(GROUP.collapse));
     // Save Case Selection
@@ -195,7 +195,7 @@ function loadUserData() {
   timerEnabled = loadBoolean("timerEnabled", timerEnabled);
   recapEnabled = loadBoolean("recapEnabled", recapEnabled);
 
-  for (const GROUP of GROUPS) {
+  for (const GROUP of GROUPS.values()) {
     // Load collapse state
     GROUP.collapse = loadList(GROUP, "collapse", false);
     // Load Case Selection
@@ -222,9 +222,10 @@ function loadUserData() {
 
   // Set learning state of some cases on first visit, so that the user can see the options
   if (firstVisit) {
-    GROUPS[0].caseSelection[0] = 1;
-    GROUPS[0].caseSelection[1] = 1;
-    GROUPS[0].caseSelection[2] = 2;
+    const BASIC_GROUP = getGroupByIndex(0);
+    BASIC_GROUP.setCaseState(0, 1);
+    BASIC_GROUP.setCaseState(1, 1);
+    BASIC_GROUP.setCaseState(2, 2);
   }
 
   updateCheckboxStatus();
@@ -335,7 +336,7 @@ function exportToURL() {
   if (baseURL == "http://127.0.0.1:5500") baseURL = "http://127.0.0.1:5500/F2LTrainer/index.html";
 
   exportURL = baseURL + "?";
-  GROUPS.forEach((group, i) => {
+  forEachGroup((group, i) => {
     // Case selection
     const caseSelection = group.caseSelection;
     const caseSelectionString = caseSelection.join("");
@@ -360,7 +361,7 @@ function importFromURL() {
   if (!urlParams.size) return;
 
   if (confirm("Import data from URL?")) {
-    GROUPS.forEach((group, i) => {
+    forEachGroup((group, i) => {
       const saveName = group.saveNameCasesURL;
       const base62String = urlParams.get(group.saveNameCasesURL);
       if (base62String === null) return;
@@ -447,8 +448,8 @@ function migrateCaseNumbers() {
   const EXPECTED_ARRAY_LENGTH = 42;
 
   // We could probably just use index 0,1 since they most likely will not change, but just to be sure use idName
-  let groupBasic = GROUPS[GROUPS.findIndex((g) => g.idName === "Basic")];
-  let groupBasicBack = GROUPS[GROUPS.findIndex((g) => g.idName === "BasicBack")];
+  let groupBasic = GROUPS.get("Basic");
+  let groupBasicBack = GROUPS.get("BasicBack");
 
   // Load solveCounter for each group and check length
   [groupBasic, groupBasicBack].forEach((g) => {


### PR DESCRIPTION
## Summary
- introduce a Group class to encapsulate F2L collections and expose helpers for DOM, algorithms, and state management
- register groups in a Map keyed by id and refactor main UI logic to consume the new API
- update TrainCase, persistence, and auxiliary loaders to work with the registry helpers

## Testing
- not run (UI only)


------
https://chatgpt.com/codex/tasks/task_e_68de564981c0832d9194135ba389cf81